### PR TITLE
Removed grabbing episode id from window url

### DIFF
--- a/pages/stream/[episodeId].js
+++ b/pages/stream/[episodeId].js
@@ -13,10 +13,10 @@ import Loading from "../../components/small-components/Loading";
 import { BsFillPlayFill } from "react-icons/bs";
 
 export const getServerSideProps = async (context) => {
-  const { episodeId } = context.query;
+  const { episode } = context.query;
 
   const res = await fetch(
-    `https://webdis-x51w.onrender.com/vidcdn/watch/${episodeId}`
+    `https://webdis-x51w.onrender.com/vidcdn/watch/${episode}`
   );
 
   const data = await res.json();
@@ -24,11 +24,12 @@ export const getServerSideProps = async (context) => {
   return {
     props: {
       data,
+      episode
     },
   };
 };
 
-function StreamingPage({ data }) {
+function StreamingPage({ data, episode }) {
   const router = useRouter();
 
   const [isExternalPlayer, setIsExternalPlayer] = React.useState(true);
@@ -36,7 +37,7 @@ function StreamingPage({ data }) {
 
   // get the search id from the url with javascript
 
-  const episodeId = window.location.pathname.split("/")[2];
+  const episodeId = episode;
 
   // if (!episodeId) {
   //   return <MainLayout>loading...</MainLayout>;


### PR DESCRIPTION
If a user were to hit refresh, or if they visited the watch page directly, the watch page wouldn't load